### PR TITLE
Fixed integration tests and decomposed WaypointQueryServlet to make testing easier

### DIFF
--- a/src/main/java/com/google/sps/servlets/DatabaseServlet.java
+++ b/src/main/java/com/google/sps/servlets/DatabaseServlet.java
@@ -50,7 +50,7 @@ public class DatabaseServlet extends HttpServlet {
     myMap.put("bellflower", "[{\"latitude\": 41.843539, \"longitude\": -87.647480, \"common_name\": {\"name\": \"bellflower\"}}]");
     myMap.put("tulip", "[{\"latitude\": 41.855223, \"longitude\": -87.631930, \"common_name\": {\"name\": \"tulip\"}}]");
     myMap.put("mushroom", "[{\"latitude\": 41.898864, \"longitude\": -87.622965, \"common_name\": {\"name\": \"mushroom\"}}, {\"latitude\": 41.898912, \"longitude\": -87.642910, \"common_name\": {\"name\": \"mushroom\"}}]");
-    myMap.put("meadowsweet", "[{\"latitude\": 41.897427, \"longitude\": -87.619934, \"common_name\": {\"name\": \"park\"}}]");
+    myMap.put("meadowsweet", "[{\"latitude\": 41.897523, \"longitude\": -87.619934, \"common_name\": {\"name\": \"meadowsweet\"}}]");
     myMap.put("sunflower", "[{\"latitude\": 41.897521, \"longitude\": -87.619934, \"common_name\": {\"name\": \"sunflower\"}}]");
     myMap.put("tree", "[{\"latitude\": 41.897219, \"longitude\": -87.622235, \"common_name\": {\"name\": \"tree\"}}]");
     myMap.put("lichen", "[{\"latitude\": 41.897219, \"longitude\": -87.622235, \"common_name\": {\"name\": \"lichen\"}}]");

--- a/src/test/java/com/google/sps/WaypointQueryServletPostTest.java
+++ b/src/test/java/com/google/sps/WaypointQueryServletPostTest.java
@@ -15,9 +15,6 @@
 package com.google.sps;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.net.HttpURLConnection;
-import java.net.URL;  
-import java.io.BufferedReader;
 
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
@@ -39,7 +36,7 @@ import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
 @RunWith(PowerMockRunner.class)
-@PrepareForTest({WaypointQueryServlet.class, URL.class, BufferedReader.class})
+@PrepareForTest(WaypointQueryServlet.class)
 public class WaypointQueryServletPostTest {
   public static final ArrayList<Coordinate> DAISY = new ArrayList<Coordinate>(Arrays.asList(new Coordinate(-87.62944, 41.84864, "daisy")));
   public static final ArrayList<Coordinate> CLOVER = new ArrayList<Coordinate>(Arrays.asList(new Coordinate(-87.63566666666667, 41.856, "clover")));
@@ -56,16 +53,6 @@ public class WaypointQueryServletPostTest {
   public static final String SUNFLOWER_BACKEND = "[{\"latitude\": 41.897521, \"longitude\": -87.619934, \"common_name\": {\"name\": \"sunflower\"}}]";
   public static final String NOTHING_BACKEND = "[]";
   private WaypointQueryServlet servlet;
-
-  public class UrlWrapper {
-    URL url;
-    public UrlWrapper(String spec) throws IOException {
-      url = new URL(spec);
-    }
-    public HttpURLConnection openConnection() throws IOException {
-      return (HttpURLConnection) url.openConnection();
-    }
-  }
   
   @Mock (name = "waypoints")
   ArrayList<ArrayList<Coordinate>> waypointMock;
@@ -77,42 +64,32 @@ public class WaypointQueryServletPostTest {
   StringWriter stringWriter;
   @Mock
   PrintWriter writer;
-  @Mock
-  UrlWrapper url;
-  @Mock
-  HttpURLConnection con;
-  @Mock
-  BufferedReader bufferedReader;
 
   @Before
-  public void before() {
+  public void before() throws Exception {
     request = mock(HttpServletRequest.class);       
     response = mock(HttpServletResponse.class);  
     servlet = PowerMockito.spy(new WaypointQueryServlet());
     PowerMockito.mockStatic(WaypointQueryServlet.class);
 
-    stringWriter = new StringWriter();
-    writer = new PrintWriter(stringWriter);
-
     // Propagate private variable with data
     waypointMock = new ArrayList<ArrayList<Coordinate>>();
+    ReflectionTestUtils.setField(servlet, "waypoints", waypointMock);
 
-    url = mock(UrlWrapper.class);
-    con = mock(HttpURLConnection.class);
-    bufferedReader = mock(BufferedReader.class);
+    stringWriter = new StringWriter();
+    writer = new PrintWriter(stringWriter);
+    when(response.getWriter()).thenReturn(writer);
+
+    PowerMockito.doReturn(null).when(WaypointQueryServlet.class, "analyzeSyntaxText", anyString());
+    PowerMockito.doNothing().when(WaypointQueryServlet.class, "storeInputAndWaypoints", anyString(), eq(waypointMock));
   }
 
   /* UNIT TESTS */
   @Test // Empty input
   public void testServletPostEmpty() throws Exception {
-    // Set the private variable values here by reflection.
-    ReflectionTestUtils.setField(servlet, "waypoints", waypointMock);
     when(request.getParameter("text-input")).thenReturn("");
-    PowerMockito.doReturn(null).when(WaypointQueryServlet.class, "analyzeSyntaxText", anyString());
     PowerMockito.doReturn(NOTHING).when(WaypointQueryServlet.class, "fetchFromDatabase", anyString(), anyString());
-    PowerMockito.doNothing().when(WaypointQueryServlet.class, "storeInputAndWaypoints", anyString(), eq(waypointMock));
 
-    when(response.getWriter()).thenReturn(writer);
     servlet.doPost(request, response);
     verify(request, atLeast(1)).getParameter("text-input");
     ArrayList<ArrayList<Coordinate>> comparison = new ArrayList<ArrayList<Coordinate>>();
@@ -122,14 +99,9 @@ public class WaypointQueryServletPostTest {
 
   @Test // Post a query with one waypoint description
   public void testServletPostOne() throws Exception {
-    // Set the private variable values here by reflection.
-    ReflectionTestUtils.setField(servlet, "waypoints", waypointMock);
     when(request.getParameter("text-input")).thenReturn("daisy");
-    PowerMockito.doReturn(null).when(WaypointQueryServlet.class, "analyzeSyntaxText", anyString());
     PowerMockito.doReturn(DAISY).when(WaypointQueryServlet.class, "fetchFromDatabase", anyString(), anyString());
-    PowerMockito.doNothing().when(WaypointQueryServlet.class, "storeInputAndWaypoints", anyString(), eq(waypointMock));
 
-    when(response.getWriter()).thenReturn(writer);
     servlet.doPost(request, response);
     verify(request, atLeast(1)).getParameter("text-input");
 
@@ -141,14 +113,9 @@ public class WaypointQueryServletPostTest {
 
   @Test // Post a query with multiple waypoint descriptions
   public void testServletPostMultiple() throws Exception {
-    // Set the private variable values here by reflection.
-    ReflectionTestUtils.setField(servlet, "waypoints", waypointMock);
     when(request.getParameter("text-input")).thenReturn("daisy;clover;bellflower");
-    PowerMockito.doReturn(null).when(WaypointQueryServlet.class, "analyzeSyntaxText", anyString());
     ((PowerMockitoStubber) PowerMockito.doReturn(DAISY, CLOVER, BELLFLOWER)).when(WaypointQueryServlet.class, "fetchFromDatabase", anyString(), anyString());
-    PowerMockito.doNothing().when(WaypointQueryServlet.class, "storeInputAndWaypoints", anyString(), eq(waypointMock));
 
-    when(response.getWriter()).thenReturn(writer);
     servlet.doPost(request, response);
     verify(request, atLeast(1)).getParameter("text-input");
 
@@ -162,14 +129,9 @@ public class WaypointQueryServletPostTest {
 
   @Test // Post a query with a waypoint description that isn't in the database
   public void testServletPostBadInput() throws Exception {
-    // Set the private variable values here by reflection.
-    ReflectionTestUtils.setField(servlet, "waypoints", waypointMock);
     when(request.getParameter("text-input")).thenReturn("daisy;wrong");
-    PowerMockito.doReturn(null).when(WaypointQueryServlet.class, "analyzeSyntaxText", anyString());
     ((PowerMockitoStubber) PowerMockito.doReturn(DAISY, NOTHING)).when(WaypointQueryServlet.class, "fetchFromDatabase", anyString(), anyString());
-    PowerMockito.doNothing().when(WaypointQueryServlet.class, "storeInputAndWaypoints", anyString(), eq(waypointMock));
 
-    when(response.getWriter()).thenReturn(writer);
     servlet.doPost(request, response);
     verify(request, atLeast(1)).getParameter("text-input");
 
@@ -182,14 +144,9 @@ public class WaypointQueryServletPostTest {
 
   @Test // Post a query with waypoint descriptions separated by a lot of spacing
   public void testServletPostLotsOfSpacing() throws Exception {
-    // Set the private variable values here by reflection.
-    ReflectionTestUtils.setField(servlet, "waypoints", waypointMock);
     when(request.getParameter("text-input")).thenReturn("   daisy;    clover   ");
-    PowerMockito.doReturn(null).when(WaypointQueryServlet.class, "analyzeSyntaxText", anyString());
     ((PowerMockitoStubber) PowerMockito.doReturn(DAISY,CLOVER)).when(WaypointQueryServlet.class, "fetchFromDatabase", anyString(), anyString());
-    PowerMockito.doNothing().when(WaypointQueryServlet.class, "storeInputAndWaypoints", anyString(), eq(waypointMock));
 
-    when(response.getWriter()).thenReturn(writer);
     servlet.doPost(request, response);
     verify(request, atLeast(1)).getParameter("text-input");
 
@@ -202,14 +159,9 @@ public class WaypointQueryServletPostTest {
 
   @Test // Post a query with a waypoint description with different letter cases
   public void testServletPostDifferentCases() throws Exception {
-    // Set the private variable values here by reflection.
-    ReflectionTestUtils.setField(servlet, "waypoints", waypointMock);
     when(request.getParameter("text-input")).thenReturn("DAisY");
-    PowerMockito.doReturn(null).when(WaypointQueryServlet.class, "analyzeSyntaxText", anyString());
     ((PowerMockitoStubber) PowerMockito.doReturn(DAISY)).when(WaypointQueryServlet.class, "fetchFromDatabase", anyString(), anyString());
-    PowerMockito.doNothing().when(WaypointQueryServlet.class, "storeInputAndWaypoints", anyString(), eq(waypointMock));
 
-    when(response.getWriter()).thenReturn(writer);
     servlet.doPost(request, response);
     verify(request, atLeast(1)).getParameter("text-input");
 
@@ -221,14 +173,9 @@ public class WaypointQueryServletPostTest {
 
   @Test // Post a query with non-semicolon, non-comma punctuation delimiters
   public void testServletPostDifferentPunctuation() throws Exception {
-    // Set the private variable values here by reflection.
-    ReflectionTestUtils.setField(servlet, "waypoints", waypointMock);
     when(request.getParameter("text-input")).thenReturn("daisy! clover. bellflower");
-    PowerMockito.doReturn(null).when(WaypointQueryServlet.class, "analyzeSyntaxText", anyString());
     ((PowerMockitoStubber) PowerMockito.doReturn(DAISY, CLOVER, BELLFLOWER)).when(WaypointQueryServlet.class, "fetchFromDatabase", anyString(), anyString());
-    PowerMockito.doNothing().when(WaypointQueryServlet.class, "storeInputAndWaypoints", anyString(), eq(waypointMock));
 
-    when(response.getWriter()).thenReturn(writer);
     servlet.doPost(request, response);
     verify(request, atLeast(1)).getParameter("text-input");
 
@@ -242,14 +189,9 @@ public class WaypointQueryServletPostTest {
 
   @Test // Post a query separating feature queries within a waypoint description with spaces
   public void testServletPostSeparateSpaces() throws Exception {
-    // Set the private variable values here by reflection.
-    ReflectionTestUtils.setField(servlet, "waypoints", waypointMock);
     when(request.getParameter("text-input")).thenReturn("tree lichen");
-    PowerMockito.doReturn(null).when(WaypointQueryServlet.class, "analyzeSyntaxText", anyString());
     ((PowerMockitoStubber) PowerMockito.doReturn(TREE_LICHEN)).when(WaypointQueryServlet.class, "fetchFromDatabase", anyString(), anyString());
-    PowerMockito.doNothing().when(WaypointQueryServlet.class, "storeInputAndWaypoints", anyString(), eq(waypointMock));
 
-    when(response.getWriter()).thenReturn(writer);
     servlet.doPost(request, response);
     verify(request, atLeast(1)).getParameter("text-input");
 
@@ -262,18 +204,15 @@ public class WaypointQueryServletPostTest {
   /* INTEGRATION TESTS with fake GET from database */
   @Test // Empty input, GET request from database
   public void testServletPostEmptyIntegration() throws Exception {
-    // Set the private variable values here by reflection.
-    ReflectionTestUtils.setField(servlet, "waypoints", waypointMock);
     when(request.getParameter("text-input")).thenReturn("");
-    PowerMockito.doReturn(null).when(WaypointQueryServlet.class, "analyzeSyntaxText", anyString());
     PowerMockito.doCallRealMethod().when(WaypointQueryServlet.class, "fetchFromDatabase", anyString(), anyString());
     PowerMockito.doReturn(NOTHING_BACKEND).when(WaypointQueryServlet.class, "sendGET", anyString());
     PowerMockito.doCallRealMethod().when(WaypointQueryServlet.class, "jsonToCoordinates", anyString(), anyString());
-    PowerMockito.doNothing().when(WaypointQueryServlet.class, "storeInputAndWaypoints", anyString(), eq(waypointMock));
 
-    when(response.getWriter()).thenReturn(writer);
     servlet.doPost(request, response);
     verify(request, atLeast(1)).getParameter("text-input");
+
+    // Create answer to compare against
     ArrayList<ArrayList<Coordinate>> comparison = new ArrayList<ArrayList<Coordinate>>();
     comparison.add(NOTHING);
     assertEquals(waypointMock, comparison);
@@ -281,18 +220,15 @@ public class WaypointQueryServletPostTest {
   
   @Test // Post a query with one waypoint description, GET request from database
   public void testServletPostOneIntegration() throws Exception {
-    // Set the private variable values here by reflection.
-    ReflectionTestUtils.setField(servlet, "waypoints", waypointMock);
     when(request.getParameter("text-input")).thenReturn("daisy");
-    PowerMockito.doReturn(null).when(WaypointQueryServlet.class, "analyzeSyntaxText", anyString());
     PowerMockito.doCallRealMethod().when(WaypointQueryServlet.class, "fetchFromDatabase", anyString(), anyString());
     PowerMockito.doReturn(DAISY_BACKEND).when(WaypointQueryServlet.class, "sendGET", anyString());
     PowerMockito.doCallRealMethod().when(WaypointQueryServlet.class, "jsonToCoordinates", anyString(), anyString());
-    PowerMockito.doNothing().when(WaypointQueryServlet.class, "storeInputAndWaypoints", anyString(), eq(waypointMock));
 
-    when(response.getWriter()).thenReturn(writer);
     servlet.doPost(request, response);
     verify(request, atLeast(1)).getParameter("text-input");
+
+    // Create answer to compare against
     ArrayList<ArrayList<Coordinate>> comparison = new ArrayList<ArrayList<Coordinate>>();
     comparison.add(DAISY);
     assertEquals(waypointMock, comparison);
@@ -300,18 +236,15 @@ public class WaypointQueryServletPostTest {
 
   @Test // One waypoint description with multiple instances, GET request from database
   public void testServletPostOneMultipleInstances() throws Exception {
-    // Set the private variable values here by reflection.
-    ReflectionTestUtils.setField(servlet, "waypoints", waypointMock);
     when(request.getParameter("text-input")).thenReturn("raspberry");
-    PowerMockito.doReturn(null).when(WaypointQueryServlet.class, "analyzeSyntaxText", anyString());
     PowerMockito.doCallRealMethod().when(WaypointQueryServlet.class, "fetchFromDatabase", anyString(), anyString());
     PowerMockito.doReturn(RASPBERRY_BACKEND).when(WaypointQueryServlet.class, "sendGET", anyString());
     PowerMockito.doCallRealMethod().when(WaypointQueryServlet.class, "jsonToCoordinates", anyString(), anyString());
-    PowerMockito.doNothing().when(WaypointQueryServlet.class, "storeInputAndWaypoints", anyString(), eq(waypointMock));
 
-    when(response.getWriter()).thenReturn(writer);
     servlet.doPost(request, response);
     verify(request, atLeast(1)).getParameter("text-input");
+
+    // Create answer to compare against
     ArrayList<ArrayList<Coordinate>> comparison = new ArrayList<ArrayList<Coordinate>>();
     comparison.add(RASPBERRY);
     assertEquals(waypointMock, comparison);
@@ -319,18 +252,15 @@ public class WaypointQueryServletPostTest {
 
   @Test // Two features that have the exact same coordinates
   public void testServletPostSameCoordinates() throws Exception {
-    // Set the private variable values here by reflection.
-    ReflectionTestUtils.setField(servlet, "waypoints", waypointMock);
     when(request.getParameter("text-input")).thenReturn("tree,lichen");
-    PowerMockito.doReturn(null).when(WaypointQueryServlet.class, "analyzeSyntaxText", anyString());
     PowerMockito.doCallRealMethod().when(WaypointQueryServlet.class, "fetchFromDatabase", anyString(), anyString());
     ((PowerMockitoStubber) PowerMockito.doReturn(TREE_BACKEND, LICHEN_BACKEND)).when(WaypointQueryServlet.class, "sendGET", anyString());
     PowerMockito.doCallRealMethod().when(WaypointQueryServlet.class, "jsonToCoordinates", anyString(), anyString());
-    PowerMockito.doNothing().when(WaypointQueryServlet.class, "storeInputAndWaypoints", anyString(), eq(waypointMock));
   
-    when(response.getWriter()).thenReturn(writer);
     servlet.doPost(request, response);
     verify(request, atLeast(1)).getParameter("text-input");
+
+    // Create answer to compare against
     ArrayList<ArrayList<Coordinate>> comparison = new ArrayList<ArrayList<Coordinate>>();
     comparison.add(TREE_LICHEN);
     assertEquals(waypointMock, comparison);
@@ -338,18 +268,15 @@ public class WaypointQueryServletPostTest {
 
   @Test // Two features that have similar coordinates
   public void testServletPostSimilarCoordinates() throws Exception {
-    // Set the private variable values here by reflection.
-    ReflectionTestUtils.setField(servlet, "waypoints", waypointMock);
     when(request.getParameter("text-input")).thenReturn("meadowsweet,sunflower");
-    PowerMockito.doReturn(null).when(WaypointQueryServlet.class, "analyzeSyntaxText", anyString());
     PowerMockito.doCallRealMethod().when(WaypointQueryServlet.class, "fetchFromDatabase", anyString(), anyString());
     ((PowerMockitoStubber) PowerMockito.doReturn(MEADOWSWEET_BACKEND, SUNFLOWER_BACKEND)).when(WaypointQueryServlet.class, "sendGET", anyString());
     PowerMockito.doCallRealMethod().when(WaypointQueryServlet.class, "jsonToCoordinates", anyString(), anyString());
-    PowerMockito.doNothing().when(WaypointQueryServlet.class, "storeInputAndWaypoints", anyString(), eq(waypointMock));
 
-    when(response.getWriter()).thenReturn(writer);
     servlet.doPost(request, response);
     verify(request, atLeast(1)).getParameter("text-input");
+
+    // Create answer to compare against
     ArrayList<ArrayList<Coordinate>> comparison = new ArrayList<ArrayList<Coordinate>>();
     comparison.add(MEADOWSWEET_SUNFLOWER);
     assertEquals(waypointMock, comparison);
@@ -357,18 +284,15 @@ public class WaypointQueryServletPostTest {
 
   @Test // Two features that have different coordinates
   public void testServletPostDifferentCoordinates() throws Exception {
-    // Set the private variable values here by reflection.
-    ReflectionTestUtils.setField(servlet, "waypoints", waypointMock);
     when(request.getParameter("text-input")).thenReturn("tree,raspberry");
-    PowerMockito.doReturn(null).when(WaypointQueryServlet.class, "analyzeSyntaxText", anyString());
     PowerMockito.doCallRealMethod().when(WaypointQueryServlet.class, "fetchFromDatabase", anyString(), anyString());
     ((PowerMockitoStubber) PowerMockito.doReturn(TREE_BACKEND, RASPBERRY_BACKEND)).when(WaypointQueryServlet.class, "sendGET", anyString());
     PowerMockito.doCallRealMethod().when(WaypointQueryServlet.class, "jsonToCoordinates", anyString(), anyString());
-    PowerMockito.doNothing().when(WaypointQueryServlet.class, "storeInputAndWaypoints", anyString(), eq(waypointMock));
 
-    when(response.getWriter()).thenReturn(writer);
     servlet.doPost(request, response);
     verify(request, atLeast(1)).getParameter("text-input");
+
+    // Create answer to compare against
     ArrayList<ArrayList<Coordinate>> comparison = new ArrayList<ArrayList<Coordinate>>();
     comparison.add(NOTHING);
     assertEquals(waypointMock, comparison);
@@ -376,18 +300,15 @@ public class WaypointQueryServletPostTest {
 
   @Test // Multiple waypoint descriptions with multiple features
   public void testServletPostMultipleDescriptionsAndFeatures() throws Exception {
-    // Set the private variable values here by reflection.
-    ReflectionTestUtils.setField(servlet, "waypoints", waypointMock);
     when(request.getParameter("text-input")).thenReturn("tree,lichen; raspberry");
-    PowerMockito.doReturn(null).when(WaypointQueryServlet.class, "analyzeSyntaxText", anyString());
     PowerMockito.doCallRealMethod().when(WaypointQueryServlet.class, "fetchFromDatabase", anyString(), anyString());
     ((PowerMockitoStubber) PowerMockito.doReturn(TREE_BACKEND, LICHEN_BACKEND, RASPBERRY_BACKEND)).when(WaypointQueryServlet.class, "sendGET", anyString());
     PowerMockito.doCallRealMethod().when(WaypointQueryServlet.class, "jsonToCoordinates", anyString(), anyString());
-    PowerMockito.doNothing().when(WaypointQueryServlet.class, "storeInputAndWaypoints", anyString(), eq(waypointMock));
 
-    when(response.getWriter()).thenReturn(writer);
     servlet.doPost(request, response);
     verify(request, atLeast(1)).getParameter("text-input");
+
+    // Create answer to compare against
     ArrayList<ArrayList<Coordinate>> comparison = new ArrayList<ArrayList<Coordinate>>();
     comparison.add(TREE_LICHEN);
     comparison.add(RASPBERRY);


### PR DESCRIPTION
Now the whole call to the database is easily mocked, but all the parsing given the response from the database can be tested independently