### PR TITLE
loop vs one way bounding boxes, query phrases in quotes, limit to research grade

### DIFF
--- a/src/main/java/com/google/sps/servlets/WaypointQueryServlet.java
+++ b/src/main/java/com/google/sps/servlets/WaypointQueryServlet.java
@@ -39,6 +39,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Calendar;
 import java.util.regex.Pattern;
+import java.util.regex.Matcher;
 import java.util.zip.DataFormatException;
 import java.text.DecimalFormat;
 import java.text.Normalizer;
@@ -56,7 +57,7 @@ import opennlp.tools.postag.POSTaggerME;
 @WebServlet("/query")
 public class WaypointQueryServlet extends HttpServlet {
   private static final Pattern INT_PATTERN = Pattern.compile("^\\d+$"); // Improves performance by avoiding compile of pattern in every method call
-  private static final Pattern WAYPOINT_PATTERN = Pattern.compile("([^\"]\\S*|\".+?\")[\\s\\p{Punct}&&[\"]]*"); // Splitting on whitespace and punctuation unless there are double quotes
+  private static final Pattern WAYPOINT_PATTERN = Pattern.compile("([^\"]\\w*|\".+?\")\\s*"); // Splitting on whitespace and punctuation unless there are double quotes
   private static final ImmutableMap<String, Integer> NUMBER_MAP = ImmutableMap.<String, Integer>builder()
     .put("one", 1).put("two", 2).put("three", 3).put("four", 4).put("five", 5).put("six", 6).put("seven", 7)
     .put("eight", 8).put("nine", 9).put("ten", 10).build(); 
@@ -66,7 +67,8 @@ public class WaypointQueryServlet extends HttpServlet {
   private final String FETCH_FIELD = "queryFetched";
   private final String FETCH_PROPERTY = "waypoints";
   private final String ENTITY_TYPE = "Route";
-  private static final Double BOUNDING_BOX_WIDTH = 0.07246376811; // 5 miles
+  private static final Double LOOP_BOUNDING_BOX_WIDTH = 0.07246376811; // 5 miles
+  private static final Double ONE_WAY_BOUNDING_BOX_WIDTH = 0.0036231884; // 0.25 miles
   private static final String NOUN_SINGULAR_OR_MASS = "NN";
   private static final String NOUN_PLURAL = "NNS";
   private static final String PRONOUN = "PRP";
@@ -89,7 +91,7 @@ public class WaypointQueryServlet extends HttpServlet {
     Coordinate end = getEnd(sessionDataStore);
     ArrayList<List<Coordinate>> waypoints = new ArrayList<List<Coordinate>>();
     try {
-      waypoints = getLocations(input, midpoint);
+      waypoints = getLocations(input, start, end);
     } catch (IllegalArgumentException e) { // User puts down a number that's out of range
       System.out.println("ILLEGAL ARGUMENT");
       response.setStatus(HttpServletResponse.SC_REQUEST_ENTITY_TOO_LARGE);
@@ -111,9 +113,9 @@ public class WaypointQueryServlet extends HttpServlet {
   /** Using the input text, fetches waypoints from the database to be 
     * used by the frontend. Returns possible waypoints. 
     */
-  public ArrayList<List<Coordinate>> getLocations(String input, Coordinate midpoint) throws IllegalArgumentException, Exception {
+  public ArrayList<List<Coordinate>> getLocations(String input, Coordinate start, Coordinate end) throws IllegalArgumentException, Exception {
     // Parse out feature requests from input
-    ArrayList<WaypointDescription> waypointRequests = processInputText(input);
+    ArrayList<WaypointDescription> waypointRequests = parseInput(input);
     ArrayList<List<Coordinate>> waypoints = new ArrayList<List<Coordinate>>();    
 
     for (WaypointDescription waypointDescription : waypointRequests) {
@@ -121,7 +123,7 @@ public class WaypointQueryServlet extends HttpServlet {
       String query = waypointDescription.getQuery();
       String feature = waypointDescription.getFeature();
       // Make call to database
-      ArrayList<Coordinate> locations = fetchFromDatabase(query, feature, midpoint);
+      ArrayList<Coordinate> locations = fetchFromDatabase(query, feature, start, end);
       if (locations.isEmpty()) { // Not in the database
         continue;
       } else {
@@ -132,36 +134,22 @@ public class WaypointQueryServlet extends HttpServlet {
     return waypoints;
   }
 
-  /** Parses the input string to separate out all the features
+  /** Parses out the features/waypoints from an input query
     * For each arraylist of strings, the first element is the general waypoint query
     */
-  public ArrayList<WaypointDescription> processInputText(String input) throws IllegalArgumentException, Exception {
+  public ArrayList<WaypointDescription> parseInput(String input) throws IllegalArgumentException, Exception {
     input = Normalizer.normalize(input, Normalizer.Form.NFKD);
     ArrayList<WaypointDescription> allWaypoints = new ArrayList<WaypointDescription>();
-    // Separate on newlines and punctuation: semicolon, period, question mark, exclamation mark, plus sign
-    // String[] waypointQueries = input.split("[;.?!+\\n]+");
-    // for (String waypointQuery : waypointQueries) {
-    //   ArrayList<WaypointDescription> waypointsFromQuery = parseWaypointQuery(waypointQuery);
-    //   allWaypoints.addAll(waypointsFromQuery);
-    // }
-    ArrayList<WaypointDescription> waypointsFromQuery = parseWaypointQuery(input);
-    return allWaypoints;
-  }
-
-  /** Parses out the features from a waypoint query
-    */
-  public ArrayList<WaypointDescription> parseWaypointQuery(String waypointQuery) throws IllegalArgumentException, Exception {
-    waypointQuery = waypointQuery.toLowerCase().trim(); // determine -- keep lowercase or allow uppercase?
-    ArrayList<WaypointDescription> waypointsFromQuery = new ArrayList<WaypointDescription>();
+    String waypointQuery = input.toLowerCase().trim(); // determine -- keep lowercase or allow uppercase?
     // Separate on commas and spaces
     //String[] featureQueries = waypointQuery.split("[,\\s]+"); 
-    List<String> list = new ArrayList<>
-    Matcher m = Pattern.compile("([^\"]\\S*|\".+?\")\\s*").matcher(str);
+    List<String> list = new ArrayList<String>();
+    Matcher m = WAYPOINT_PATTERN.matcher(waypointQuery);
     while (m.find()) {
-      list.add(m.group(1).replace("\"", ""));
-    }
-    for (String el : list) {
-      System.out.println(el);
+      String queryString = m.group(1).replaceAll("\\p{Punct}", "");
+      if (!queryString.isEmpty()) {
+        list.add(queryString);
+      }
     }
     String[] featureQueries = list.toArray(new String[0]);
     String[][] bigTags = getTags(featureQueries);
@@ -169,6 +157,11 @@ public class WaypointQueryServlet extends HttpServlet {
     WaypointDescription waypoint = new WaypointDescription();
     for (int i = 0; i < featureQueries.length; i++) {
       String feature = featureQueries[i]; 
+      System.out.print(feature + "  " + primaryTags[i]);
+      if (bigTags.length == 2) {
+        System.out.println("   " + bigTags[1][i]);
+      }
+
       if (feature.isEmpty()) {
         continue;
       }
@@ -179,37 +172,32 @@ public class WaypointQueryServlet extends HttpServlet {
         }
         if (waypoint.hasFeature()) { 
           // Start a new waypoint description
-          waypointsFromQuery.add(waypoint);
+          allWaypoints.add(waypoint);
           waypoint = new WaypointDescription(maxAmount);
         } else {
           waypoint.setMaxAmount(maxAmount);
         }
       } else {
         // Parsing for nouns/not pronouns
-        // System.out.println(feature);
-        // System.out.println(primaryTags[i]);
-        // if (bigTags.length == 2) {
-        //   System.out.println(bigTags[1][i]);
-        // }
         if (primaryTags[i].equals(NOUN_SINGULAR_OR_MASS) || primaryTags[i].equals(NOUN_PLURAL)) { // Doesn't look for proper nouns right now
           waypoint.addFeature(feature);
-          waypointsFromQuery.add(waypoint);
+          allWaypoints.add(waypoint);
           waypoint = new WaypointDescription();
         } else if (bigTags.length == 2 && !primaryTags[i].equals(PRONOUN)) { 
           // Second chance: as long as it's not a pronoun, see if the word can still be a noun
           String[] secondaryTags = bigTags[1];
           if (secondaryTags[i].equals(NOUN_SINGULAR_OR_MASS) || secondaryTags[i].equals(NOUN_PLURAL)) {
             waypoint.addFeature(feature);
-            waypointsFromQuery.add(waypoint);
+            allWaypoints.add(waypoint);
             waypoint = new WaypointDescription();
           }
         }
       }
     }
     if (waypoint.hasFeature()) {
-      waypointsFromQuery.add(waypoint);
+      allWaypoints.add(waypoint);
     }
-    return waypointsFromQuery;
+    return allWaypoints;
   }
 
   /** Gets the part of speech tags for a sentence of tokens
@@ -230,14 +218,14 @@ public class WaypointQueryServlet extends HttpServlet {
   /** Determines if the passed in string is a number 
     */
   public boolean isInt(String word) {
-    return PATTERN.matcher(word).matches() || NUMBER_MAP.containsKey(word)
+    return INT_PATTERN.matcher(word).matches() || NUMBER_MAP.containsKey(word)
       || word.equals("all") || word.equals("every");
   }
 
   /** Assuming that the passed in string is a number, converts it to an int
     */
   public int wordToInt(String word) throws Exception {
-    if (PATTERN.matcher(word).matches()) {
+    if (INT_PATTERN.matcher(word).matches()) {
       return Integer.parseInt(word);
     } else if (NUMBER_MAP.containsKey(word)) {
       return NUMBER_MAP.get(word);
@@ -250,9 +238,9 @@ public class WaypointQueryServlet extends HttpServlet {
   /** Sends a request for the input feature to the database
     * Returns the Coordinate matching the input feature 
     */ 
-  public ArrayList<Coordinate> fetchFromDatabase(String query, String label, Coordinate midpoint) throws IOException {
+  public ArrayList<Coordinate> fetchFromDatabase(String query, String label, Coordinate start, Coordinate end) throws IOException {
     String startDate = getStartDate();
-    String[] boundaries = getBoundingBox();
+    String[] boundaries = getBoundingBox(start, end);
     String json = sendGET(query, startDate, boundaries);
     if (json != null) {
       return jsonToCoordinates(json, label);
@@ -277,12 +265,29 @@ public class WaypointQueryServlet extends HttpServlet {
     * the midpoint by BOUNDING_BOX_WIDTH on each side
     * Returns list in order of bound: west, east, south, north
     */
-  public String[] getBoundingBox(Coordinate midpoint) {
+  public static String[] getBoundingBox(Coordinate start, Coordinate end) {
     String[] boundaries = new String[4];
-    boundaries[0] = String.valueOf(midpoint.getX() - BOUNDING_BOX_WIDTH);
-    boundaries[1] = String.valueOf(midpoint.getX() + BOUNDING_BOX_WIDTH);
-    boundaries[2] = String.valueOf(midpoint.getY() - BOUNDING_BOX_WIDTH);
-    boundaries[3] = String.valueOf(midpoint.getY() + BOUNDING_BOX_WIDTH);
+    if (start.equals(end)) { // loop
+      boundaries[0] = String.valueOf(start.getX() - LOOP_BOUNDING_BOX_WIDTH);
+      boundaries[1] = String.valueOf(start.getX() + LOOP_BOUNDING_BOX_WIDTH);
+      boundaries[2] = String.valueOf(start.getY() - LOOP_BOUNDING_BOX_WIDTH);
+      boundaries[3] = String.valueOf(start.getY() + LOOP_BOUNDING_BOX_WIDTH);
+    } else { // one-way
+      if (start.getX() > end.getX()) {
+        boundaries[0] = String.valueOf(end.getX() - ONE_WAY_BOUNDING_BOX_WIDTH);
+        boundaries[1] = String.valueOf(start.getX() + ONE_WAY_BOUNDING_BOX_WIDTH);
+      } else {
+        boundaries[0] = String.valueOf(start.getX() - ONE_WAY_BOUNDING_BOX_WIDTH);
+        boundaries[1] = String.valueOf(end.getX() + ONE_WAY_BOUNDING_BOX_WIDTH);
+      }
+      if (start.getY() > end.getY()) {
+        boundaries[2] = String.valueOf(end.getY() - ONE_WAY_BOUNDING_BOX_WIDTH);
+        boundaries[3] = String.valueOf(start.getY() + ONE_WAY_BOUNDING_BOX_WIDTH);
+      } else {
+        boundaries[2] = String.valueOf(start.getY() - ONE_WAY_BOUNDING_BOX_WIDTH);
+        boundaries[3] = String.valueOf(end.getY() + ONE_WAY_BOUNDING_BOX_WIDTH);
+      }
+    }
     return boundaries;
   }
 
@@ -294,6 +299,7 @@ public class WaypointQueryServlet extends HttpServlet {
     String query = "https://www.inaturalist.org/observations.json?q=" + feature;
     query += "&d1=" + startDate;
     query += "&swlng=" + bounds[0] + "&nelng=" + bounds[1] + "&swlat=" + bounds[2] + "&nelat=" + bounds[3];
+    query += "&quality_grade=research";
     URL obj = new URL(query); 
     
     HttpURLConnection con = (HttpURLConnection) obj.openConnection();

--- a/src/main/webapp/create-route.html
+++ b/src/main/webapp/create-route.html
@@ -49,7 +49,7 @@
             <h3> Step 1: </h3>
             <p> 
             Type in whatever nature features you want to see! You can specify a limit to how many 
-            results you want for each feature(s)! If you want to query a specific phrase, put it in
+            results you want for each feature(s)! If you want to query a specific multi-word phrase, put it in
             quotation marks
             <br>
             <i> Example: mushroom, 2 clovers, and "california poppy" </i>

--- a/src/main/webapp/create-route.html
+++ b/src/main/webapp/create-route.html
@@ -48,8 +48,11 @@
             <div class="p-3">
             <h3> Step 1: </h3>
             <p> 
-            Type in what you want to see! You can specify a limit to how many results you want for each feature(s)!
-            <i> Example: daisy, 2 clovers </i>
+            Type in whatever nature features you want to see! You can specify a limit to how many 
+            results you want for each feature(s)! If you want to query a specific phrase, put it in
+            quotation marks
+            <br>
+            <i> Example: mushroom, 2 clovers, and "california poppy" </i>
             </p>
             <form action="/query" method="POST" id ="text-git statform">
 

--- a/src/test/java/com/google/sps/WaypointQueryServletTest.java
+++ b/src/test/java/com/google/sps/WaypointQueryServletTest.java
@@ -43,14 +43,14 @@ import org.powermock.modules.junit4.PowerMockRunner;
 @RunWith(PowerMockRunner.class)
 @PrepareForTest(WaypointQueryServlet.class)
 public class WaypointQueryServletTest {
-  public static final ArrayList<Coordinate> DAISY = new ArrayList<Coordinate>(Arrays.asList(new Coordinate(-87.62944, 41.84864, "daisy")));
+  public static final ArrayList<Coordinate> MUSHROOM = new ArrayList<Coordinate>(Arrays.asList(new Coordinate(-87.62944, 41.84864, "mushroom")));
   public static final ArrayList<Coordinate> CLOVER = new ArrayList<Coordinate>(Arrays.asList(new Coordinate(-87.63566666666667, 41.856, "clover")));
   public static final ArrayList<Coordinate> BELLFLOWER = new ArrayList<Coordinate>(Arrays.asList(new Coordinate(-87.6475, 41.8435, "bellflower")));
   public static final ArrayList<Coordinate> RASPBERRY = new ArrayList<Coordinate>(Arrays.asList(new Coordinate(-87.62212, 41.89796, "raspberry"), new Coordinate(-87.62456, 41.89696, "raspberry"), new Coordinate(-87.62392, 41.88844, "raspberry")));
   public static final ArrayList<Coordinate> TREE_LICHEN = new ArrayList<Coordinate>(Arrays.asList(new Coordinate(-87.62224, 41.8972, "tree,lichen")));
   public static final ArrayList<Coordinate> MEADOWSWEET_SUNFLOWER = new ArrayList<Coordinate>(Arrays.asList(new Coordinate(-87.61992, 41.89752, "meadowsweet,sunflower")));
   public static final ArrayList<Coordinate> NOTHING = new ArrayList<Coordinate>();
-  public static final String DAISY_BACKEND = "[{\"latitude\": 41.848653, \"longitude\": -87.629454, \"common_name\": {\"name\": \"daisy\"}}]";
+  public static final String MUSHROOM_BACKEND = "[{\"latitude\": 41.848653, \"longitude\": -87.629454, \"common_name\": {\"name\": \"mushroom\"}}]";
   public static final String RASPBERRY_BACKEND = "[{\"latitude\": 41.897946, \"longitude\": -87.622112, \"common_name\": {\"name\": \"raspberry\"}}, {\"latitude\": 41.896968, \"longitude\": -87.624580, \"common_name\": {\"name\": \"raspberry\"}}, {\"latitude\": 41.888454, \"longitude\": -87.623920, \"common_name\": {\"name\": \"raspberry\"}}]";
   public static final String TREE_BACKEND = "[{\"latitude\": 41.897219, \"longitude\": -87.622235, \"common_name\": {\"name\": \"tree\"}}]";
   public static final String LICHEN_BACKEND = "[{\"latitude\": 41.897219, \"longitude\": -87.622235, \"common_name\": {\"name\": \"lichen\"}}]";
@@ -58,30 +58,32 @@ public class WaypointQueryServletTest {
   public static final String SUNFLOWER_BACKEND = "[{\"latitude\": 41.897521, \"longitude\": -87.619934, \"common_name\": {\"name\": \"sunflower\"}}]";
   public static final String NOTHING_BACKEND = "[]";
   public static final String COMPARISON_DATE = "2019-08-01";
-  public static final String MULT_FEATURES_ONE_WAYPOINT_QUERY = "daisy,cLover     raSpbeRRy   ";
-  public static final String NUMBER_BEGINNING_QUERY = "2 daisy,cLover,raspberry";
-  public static final String NUMBER_MIDDLE_QUERY = "tree,2 daisy, clover, raspberry";
-  public static final String ONE_FEATURE_MULT_WAYPOINT_QUERY = "daisy;+clover.raspberry!!?\ntree";
-  public static final String MULT_FEATURES_MULT_WAYPOINT_QUERY = "daisy,clover  raspberry; tree";
+  public static final String MULT_FEATURES_ONE_WAYPOINT_QUERY = "mushroom,cLover     raSpbeRRy   ";
+  public static final String NUMBER_BEGINNING_QUERY = "2 mushroom,cLover,raspberry";
+  public static final String NUMBER_MIDDLE_QUERY = "tree,2 mushroom, clover, raspberry";
+  public static final String ONE_FEATURE_MULT_WAYPOINT_QUERY = "mushroom;+.raspberry!!?\ntree";
+  public static final String MULT_FEATURES_MULT_WAYPOINT_QUERY = "mushroom,  raspberry; tree";
   public static final int MAX_AMOUNT = 2;
-  public static final WaypointDescription DAISY_DESC = new WaypointDescription("daisy");
-  public static final WaypointDescription DAISY_WITH_NUMBER = new WaypointDescription(MAX_AMOUNT, "daisy");
+  public static final WaypointDescription MUSHROOM_DESC = new WaypointDescription("mushroom");
+  public static final WaypointDescription MUSHROOM_WITH_NUMBER = new WaypointDescription(MAX_AMOUNT, "mushroom");
   public static final WaypointDescription CLOVER_DESC = new WaypointDescription("clover");
   public static final WaypointDescription RASPBERRY_DESC = new WaypointDescription("raspberry");
   public static final WaypointDescription TREE_DESC = new WaypointDescription("tree");
+  public static final WaypointDescription GREAT_BLUE_HERON = new WaypointDescription("great blue heron");
   public static final ArrayList<String> TREE_WORD = new ArrayList<String>(Arrays.asList("tree"));
   public static final ArrayList<String> LICHEN_WORD = new ArrayList<String>(Arrays.asList("lichen"));
-  public static final ArrayList<String> DAISY_WORD = new ArrayList<String>(Arrays.asList("daisy"));
+  public static final ArrayList<String> MUSHROOM_WORD = new ArrayList<String>(Arrays.asList("mushroom"));
   public static final ArrayList<String> CLOVER_WORD = new ArrayList<String>(Arrays.asList("clover"));
   public static final ArrayList<String> RASPBERRY_WORD = new ArrayList<String>(Arrays.asList("raspberry"));
-  private static final Coordinate midpointMock = new Coordinate(-87.62940, 41.84865, "midpoint");
-  private static final String[] MIDPOINT_COMPARISON = {"-87.70186376811", "-87.55693623189", "41.77618623189", "41.92111376811"};
+  private static final Coordinate START = new Coordinate(-87.62940, 41.84865, "start");
+  private static final Coordinate END = new Coordinate(-87.62942, 41.84861, "end");
+  private static final String[] LOOP_COMPARISON = {"-87.70186376811", "-87.55693623189", "41.77618623189", "41.92111376811"};
+  private static final String[] ONE_WAY_COMPARISON = {"-87.6330431884", "-87.6257768116", "41.8449868116", "41.8522731884"};
   private WaypointQueryServlet servlet;
 
   @Before
   public void before() throws Exception { 
     servlet = PowerMockito.spy(new WaypointQueryServlet());
-    ReflectionTestUtils.setField(servlet, "midpoint", midpointMock);
   }
 
   /* Testing getStartDate */
@@ -94,25 +96,32 @@ public class WaypointQueryServletTest {
     assertEquals(date, COMPARISON_DATE);
   }
 
-  /* Testing getBoundingBox */
+  /* Testing getBoundingBox loop */
   @Test 
-  public void testGetBoundingBox() throws Exception {
-    String[] bounds = servlet.getBoundingBox();
-    assertEquals(bounds, MIDPOINT_COMPARISON);
+  public void testGetBoundingBoxLoop() throws Exception {
+    String[] bounds = servlet.getBoundingBox(START, START);
+    assertEquals(bounds, LOOP_COMPARISON);
+  }
+
+  /* Testing getBoundingBox one-way */
+  @Test 
+  public void testGetBoundingBoxOneWay() throws Exception {
+    String[] bounds = servlet.getBoundingBox(START, END);
+    assertEquals(bounds, ONE_WAY_COMPARISON);
   }
 
   /* Testing jsonToCoordinates */
   @Test 
   public void testJsonToCoordinates() throws Exception {
-    ArrayList<Coordinate> coordinateResult = WaypointQueryServlet.jsonToCoordinates(DAISY_BACKEND, "daisy");
-    assertEquals(coordinateResult, DAISY);
+    ArrayList<Coordinate> coordinateResult = WaypointQueryServlet.jsonToCoordinates(MUSHROOM_BACKEND, "mushroom");
+    assertEquals(coordinateResult, MUSHROOM);
   }
 
   /* Testing fetchFromDatabase when result exists; mock sendGET */
   @Test 
   public void testFetchFromDatabaseResult() throws Exception {
     PowerMockito.stub(PowerMockito.method(WaypointQueryServlet.class, "sendGET")).toReturn(TREE_BACKEND);
-    ArrayList<Coordinate> coordinateResult = servlet.fetchFromDatabase("tree", "tree,lichen");
+    ArrayList<Coordinate> coordinateResult = servlet.fetchFromDatabase("tree", "tree,lichen", START, START);
     assertEquals(coordinateResult, TREE_LICHEN);
   }
 
@@ -120,7 +129,7 @@ public class WaypointQueryServletTest {
   @Test 
   public void testFetchFromDatabaseNoResult() throws Exception {
     PowerMockito.stub(PowerMockito.method(WaypointQueryServlet.class, "sendGET")).toReturn(NOTHING_BACKEND);
-    ArrayList<Coordinate> coordinateResult = servlet.fetchFromDatabase("trash", "trash");
+    ArrayList<Coordinate> coordinateResult = servlet.fetchFromDatabase("trash", "trash", START, START);
     assertEquals(coordinateResult, NOTHING);
   }
 
@@ -141,7 +150,7 @@ public class WaypointQueryServletTest {
   /* Testing isInt on a non-number */
   @Test
   public void testIsIntNot() throws Exception {
-    boolean wordIsInt = servlet.isInt("daisy");
+    boolean wordIsInt = servlet.isInt("mushroom");
     assertFalse(wordIsInt);
   } 
 
@@ -159,90 +168,104 @@ public class WaypointQueryServletTest {
     assertEquals(newInt, MAX_AMOUNT);
   } 
 
-  /* Testing parseWaypointQuery, different cases */
+  /* Testing parseInput, different cases */
   @Test 
   public void testParseWaypointQueryCasing() throws Exception {
-    ArrayList<WaypointDescription> features = servlet.parseWaypointQuery(MULT_FEATURES_ONE_WAYPOINT_QUERY);
+    ArrayList<WaypointDescription> features = servlet.parseInput(MULT_FEATURES_ONE_WAYPOINT_QUERY);
     ArrayList<WaypointDescription> comparison = new ArrayList<WaypointDescription>();
-    comparison.add(DAISY_DESC);
+    comparison.add(MUSHROOM_DESC);
     comparison.add(CLOVER_DESC);
     comparison.add(RASPBERRY_DESC);
     assertEquals(features, comparison);
   }
 
-  /* Testing parseWaypointQuery, spaces and commas */
+  /* Testing parseInput, spaces and commas */
   @Test 
   public void testParseWaypointQuerySplit() throws Exception {
-    ArrayList<WaypointDescription> features = servlet.parseWaypointQuery(MULT_FEATURES_ONE_WAYPOINT_QUERY.toLowerCase());
+    ArrayList<WaypointDescription> features = servlet.parseInput(MULT_FEATURES_ONE_WAYPOINT_QUERY.toLowerCase());
     ArrayList<WaypointDescription> comparison = new ArrayList<WaypointDescription>();
-    comparison.add(DAISY_DESC);
+    comparison.add(MUSHROOM_DESC);
     comparison.add(CLOVER_DESC);
     comparison.add(RASPBERRY_DESC);
     assertEquals(features, comparison);
   }
 
-  /* Testing parseWaypointQuery where the query contains a number at the beginning */
+  /* Testing parseInput where the query contains a number at the beginning */
   @Test 
   public void testParseWaypointQueryNumberBeginning() throws Exception {
-    ArrayList<WaypointDescription> features = servlet.parseWaypointQuery(NUMBER_BEGINNING_QUERY);
+    ArrayList<WaypointDescription> features = servlet.parseInput(NUMBER_BEGINNING_QUERY);
     ArrayList<WaypointDescription> comparison = new ArrayList<WaypointDescription>();
-    comparison.add(DAISY_WITH_NUMBER);
+    comparison.add(MUSHROOM_WITH_NUMBER);
     comparison.add(CLOVER_DESC);
     comparison.add(RASPBERRY_DESC);
     assertEquals(features, comparison);
   }
 
-  /* Testing parseWaypointQuery where the query contains a number in the middle */
+  /* Testing parseInput where the query contains a number in the middle */
   @Test 
   public void testParseWaypointQueryNumberMiddle() throws Exception {
-    ArrayList<WaypointDescription> features = servlet.parseWaypointQuery(NUMBER_MIDDLE_QUERY);
+    ArrayList<WaypointDescription> features = servlet.parseInput(NUMBER_MIDDLE_QUERY);
     ArrayList<WaypointDescription> comparison = new ArrayList<WaypointDescription>();
     comparison.add(TREE_DESC);
-    comparison.add(DAISY_WITH_NUMBER);
+    comparison.add(MUSHROOM_WITH_NUMBER);
     comparison.add(CLOVER_DESC);
     comparison.add(RASPBERRY_DESC);
     assertEquals(features, comparison);
   }
 
-  /* Testing parseWaypointQuery with an adjective */
+  /* Testing parseInput with an adjective */
   @Test 
   public void testParseWaypointQueryAdjective() throws Exception {
-    ArrayList<WaypointDescription> features = servlet.parseWaypointQuery("amazing tree");
+    ArrayList<WaypointDescription> features = servlet.parseInput("amazing tree");
     ArrayList<WaypointDescription> comparison = new ArrayList<WaypointDescription>();
     comparison.add(TREE_DESC);
     assertEquals(features, comparison);
   }  
 
-  /* Testing parseWaypointQuery with a full sentence and just one feature */
+  /* Testing parseInput with a full sentence and just one feature */
   @Test 
   public void testParseWaypointQueryFullSentence() throws Exception {
-    ArrayList<WaypointDescription> features = servlet.parseWaypointQuery("i want to see a tree");
+    ArrayList<WaypointDescription> features = servlet.parseInput("i want to see a tree");
     ArrayList<WaypointDescription> comparison = new ArrayList<WaypointDescription>();
     comparison.add(TREE_DESC);
     assertEquals(features, comparison);
   }  
 
-  /* Testing processInputText, all punctuation, one feature per waypoint */
+  /* Testing parseInput, all punctuation, one feature per waypoint */
   @Test 
   public void testProcessInputTextPunctuation() throws Exception {
-    ArrayList<WaypointDescription> features = servlet.processInputText(ONE_FEATURE_MULT_WAYPOINT_QUERY);
+    ArrayList<WaypointDescription> features = servlet.parseInput(ONE_FEATURE_MULT_WAYPOINT_QUERY);
     ArrayList<WaypointDescription> comparison = new ArrayList<WaypointDescription>();
-    comparison.add(DAISY_DESC);
-    comparison.add(CLOVER_DESC);
+    comparison.add(MUSHROOM_DESC);
+    //comparison.add(CLOVER_DESC);
+    comparison.add(RASPBERRY_DESC);
+    comparison.add(TREE_DESC);
+    for (WaypointDescription feature : features) {
+      System.out.println(feature.getFeature());
+      //System.out.println(feature.getMaxAmount());
+    }
+    assertEquals(features, comparison);
+  }
+
+  /* Testing parseInput, multiple features and multiple waypoints */
+  @Test 
+  public void testProcessInputTextMultipleFeaturesWaypoints() throws Exception {
+    ArrayList<WaypointDescription> features = servlet.parseInput(MULT_FEATURES_MULT_WAYPOINT_QUERY);
+    ArrayList<WaypointDescription> comparison = new ArrayList<WaypointDescription>();
+    comparison.add(MUSHROOM_DESC);
+    //comparison.add(CLOVER_DESC);
     comparison.add(RASPBERRY_DESC);
     comparison.add(TREE_DESC);
     assertEquals(features, comparison);
   }
 
-  /* Testing processInputText, multiple features and multiple waypoints */
+  /* Testing parseInput with quotes */
   @Test 
-  public void testProcessInputTextMultipleFeaturesWaypoints() throws Exception {
-    ArrayList<WaypointDescription> features = servlet.processInputText(MULT_FEATURES_MULT_WAYPOINT_QUERY);
+  public void testParseWaypointQueryQuotes() throws Exception {
+    ArrayList<WaypointDescription> features = servlet.parseInput("tree \"great blue heron\"");
     ArrayList<WaypointDescription> comparison = new ArrayList<WaypointDescription>();
-    comparison.add(DAISY_DESC);
-    comparison.add(CLOVER_DESC);
-    comparison.add(RASPBERRY_DESC);
     comparison.add(TREE_DESC);
+    comparison.add(GREAT_BLUE_HERON);
     assertEquals(features, comparison);
   }
 
@@ -250,7 +273,7 @@ public class WaypointQueryServletTest {
   @Test
   public void testGetLocationsEmpty() throws Exception {
     PowerMockito.stub(PowerMockito.method(WaypointQueryServlet.class, "sendGET")).toReturn(NOTHING_BACKEND);
-    ArrayList<List<Coordinate>> locations = servlet.getLocations("");
+    ArrayList<List<Coordinate>> locations = servlet.getLocations("", START, START);
     ArrayList<List<Coordinate>> comparison = new ArrayList<List<Coordinate>>();
     assertEquals(locations, comparison);
   }
@@ -259,7 +282,7 @@ public class WaypointQueryServletTest {
   @Test
   public void testGetLocationsOne() throws Exception {
     PowerMockito.stub(PowerMockito.method(WaypointQueryServlet.class, "sendGET")).toReturn(RASPBERRY_BACKEND);
-    ArrayList<List<Coordinate>> locations = servlet.getLocations("raspberry");
+    ArrayList<List<Coordinate>> locations = servlet.getLocations("raspberry", START, START);
     ArrayList<List<Coordinate>> comparison = new ArrayList<List<Coordinate>>();
     comparison.add(RASPBERRY);
     assertEquals(locations, comparison);
@@ -269,7 +292,7 @@ public class WaypointQueryServletTest {
   @Test
   public void testGetLocationsNumber() throws Exception {
     PowerMockito.stub(PowerMockito.method(WaypointQueryServlet.class, "sendGET")).toReturn(RASPBERRY_BACKEND);
-    ArrayList<List<Coordinate>> locations = servlet.getLocations("1 raspberry");
+    ArrayList<List<Coordinate>> locations = servlet.getLocations("1 raspberry", START, START);
     ArrayList<List<Coordinate>> comparison = new ArrayList<List<Coordinate>>();
     comparison.add(Arrays.asList(RASPBERRY.get(0)));
     assertEquals(locations, comparison);


### PR DESCRIPTION
- Treat loop routes differently than one-way routes when creating a bounding box -- loops have 5 mile radius, one-way is bound between start and end with 0.25 mile buffer
- Users can specify entire phrases that they want to query the database like "great blue heron" or "California poppy"
- iNaturalist results are limited to research quality grade, meaning that they're confirmed/verified